### PR TITLE
Fix broken unit tests

### DIFF
--- a/test/index.unit.js
+++ b/test/index.unit.js
@@ -1,5 +1,6 @@
 const assert = require('assert')
 const web3Utils = require('web3-utils')
+const BigNumber = require('bignumber.js')
 
 const generation = require('../index')
 
@@ -21,7 +22,7 @@ describe('Invoice generation unit test', function () {
         assert.deepEqual(result.destinations[0].walletAddresses.length, 1)
         assert.deepEqual(result.destinations[0].walletAddresses.length, 1)
 
-        assert(web3Utils.isBigNumber(result.amount))
+        assert(BigNumber.isBigNumber(result.amount))
         assert(result.amount.isEqualTo(1))
         assert(web3Utils.isHex(result.details))
     })


### PR DESCRIPTION
Currently unit tests are broken with:
```
TypeError: web3Utils.isBigNumber is not a function
      at Context.<anonymous> (test/index.unit.js:24:26)
```